### PR TITLE
Implement MatchItem Quantifiers

### DIFF
--- a/relex/src/ast.rs
+++ b/relex/src/ast.rs
@@ -301,7 +301,7 @@ pub trait IsQuantifierType: Into<QuantifierType> {}
 #[derive(Debug, PartialEq)]
 pub enum QuantifierType {
     MatchExactRange(Integer),
-    MatchAtleastRange(Integer),
+    MatchAtLeastRange(Integer),
     MatchBetweenRange {
         lower_bound: Integer,
         upper_bound: Integer,
@@ -342,7 +342,7 @@ impl From<RangeQuantifier> for QuantifierType {
 
         match (lower_bound, upper_bound) {
             (lower, None) => QuantifierType::MatchExactRange(lower.0),
-            (lower, Some(None)) => QuantifierType::MatchAtleastRange(lower.0),
+            (lower, Some(None)) => QuantifierType::MatchAtLeastRange(lower.0),
             (lower, Some(Some(upper))) => QuantifierType::MatchBetweenRange {
                 lower_bound: lower.0,
                 upper_bound: upper.0,
@@ -357,7 +357,7 @@ pub struct LazyModifier;
 
 /// A Regex Range Qualifier representable by the following three expressions.
 /// `{n}`: Match exactly.
-/// `{n,}`: Match atleast.
+/// `{n,}`: Match at least.
 /// `{n,m}` Match between range.
 pub struct RangeQuantifier {
     lower_bound: RangeQuantifierLowerBound,

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -157,7 +157,38 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
 
             Ok(joined_block)
         }
+        Match::WithQuantifier {
+            item: MatchItem::MatchAnyCharacter,
+            quantifier: Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(cnt))),
+        } => {
+            let min_match = vec![RelativeOpcode::Any; cnt as usize];
+            let optional = vec![
+                // looping match case first (3) signifies lazy consumption
+                RelativeOpcode::Split(3, 1),
+                RelativeOpcode::Any,
+                RelativeOpcode::Jmp(-2),
+            ];
+            let joined_block = min_match.into_iter().chain(optional.into_iter()).collect();
 
+            Ok(joined_block)
+        }
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacter(MatchCharacter(Char(c))),
+            quantifier: Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(cnt))),
+        } => {
+            let min_match = vec![RelativeOpcode::Consume(c); cnt as usize];
+            let optional = vec![
+                // looping match case first (3) signifies lazy consumption
+                RelativeOpcode::Split(3, 1),
+                RelativeOpcode::Consume(c),
+                RelativeOpcode::Jmp(-2),
+            ];
+            let joined_block = min_match.into_iter().chain(optional.into_iter()).collect();
+
+            Ok(joined_block)
+        }
+
+        // Catch-all todo
         Match::WithQuantifier {
             item: _,
             quantifier: _,

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -132,7 +132,7 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
         } => {
             let min_match = vec![RelativeOpcode::Any; cnt as usize];
             let optional = vec![
-                RelativeOpcode::Split(3, 1),
+                RelativeOpcode::Split(1, 3),
                 RelativeOpcode::Any,
                 RelativeOpcode::Jmp(-2),
             ];
@@ -146,7 +146,7 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
         } => {
             let min_match = vec![RelativeOpcode::Consume(c); cnt as usize];
             let optional = vec![
-                RelativeOpcode::Split(3, 1),
+                RelativeOpcode::Split(1, 3),
                 RelativeOpcode::Consume(c),
                 RelativeOpcode::Jmp(-2),
             ];
@@ -309,7 +309,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Any,
                 Opcode::Any,
-                Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(3))),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
                 Opcode::Any,
                 Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
                 Opcode::Match
@@ -329,7 +329,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Consume(InstConsume::new('a')),
                 Opcode::Consume(InstConsume::new('a')),
-                Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(3))),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
                 Opcode::Consume(InstConsume::new('a')),
                 Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
                 Opcode::Match

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -14,7 +14,7 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
             let prefix = [
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
             ];
 
             prefix
@@ -103,7 +103,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                 Opcode::Consume(InstConsume::new('a')),
                 Opcode::Consume(InstConsume::new('b')),
                 Opcode::Match,
@@ -153,7 +153,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                 Opcode::Any,
                 Opcode::Match,
             ])),

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -14,7 +14,7 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
             let prefix = [
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
             ];
 
             prefix
@@ -56,6 +56,7 @@ fn match_item(m: ast::Match) -> Result<Opcodes, String> {
     use ast::{Char, Integer, Match, MatchCharacter, MatchItem, Quantifier, QuantifierType};
 
     match m {
+        // match exact
         Match::WithQuantifier {
             item: MatchItem::MatchAnyCharacter,
             quantifier: Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))),
@@ -64,6 +65,20 @@ fn match_item(m: ast::Match) -> Result<Opcodes, String> {
             item: MatchItem::MatchCharacter(MatchCharacter(Char(c))),
             quantifier: Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))),
         } => Ok(vec![Opcode::Consume(InstConsume::new(c)); cnt as usize]),
+        // match atleast
+        Match::WithQuantifier {
+            item: MatchItem::MatchAnyCharacter,
+            quantifier: Quantifier::Eager(QuantifierType::MatchAtleastRange(Integer(cnt))),
+        } => {
+            let min_match = vec![Opcode::Any; cnt as usize];
+            let optional = vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+            ];
+            todo!()
+        }
+
         Match::WithQuantifier {
             item: _,
             quantifier: _,
@@ -103,7 +118,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                 Opcode::Consume(InstConsume::new('a')),
                 Opcode::Consume(InstConsume::new('b')),
                 Opcode::Match,
@@ -153,7 +168,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                 Opcode::Any,
                 Opcode::Match,
             ])),

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -197,8 +197,11 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
             quantifier: Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(cnt))),
         } => generate_range_quantifier_block!(lazy, cnt, RelativeOpcode::Consume(c)),
 
+        /*
+        Blocking out until I can address a better pattern for match between generation
+
         // match between range
-        Match::WithQuantifier {
+         Match::WithQuantifier {
             item: MatchItem::MatchAnyCharacter,
             quantifier:
                 Quantifier::Eager(QuantifierType::MatchBetweenRange {
@@ -233,7 +236,7 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
                     upper_bound: Integer(upper),
                 }),
         } => generate_range_quantifier_block!(lazy, lower, upper, RelativeOpcode::Consume(c)),
-
+        */
         // Catch-all todo
         Match::WithQuantifier {
             item: _,
@@ -419,6 +422,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "unimplemented"]
     fn should_compile_match_between_quantified_item() {
         use ast::*;
         use relex_runtime::*;

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -19,32 +19,34 @@ enum RelativeOpcode {
 }
 
 impl RelativeOpcode {
-    fn to_opcode_with_index_unchecked(&self, idx: usize) -> Opcode {
+    fn to_opcode_with_index(&self, idx: usize) -> Option<Opcode> {
         match self {
-            RelativeOpcode::Any => Opcode::Any,
-            RelativeOpcode::Consume(c) => Opcode::Consume(InstConsume::new(*c)),
+            RelativeOpcode::Any => Some(Opcode::Any),
+            RelativeOpcode::Consume(c) => Some(Opcode::Consume(InstConsume::new(*c))),
             RelativeOpcode::Split(rel_x, rel_y) => {
                 let signed_idx = idx as isize;
-                let x = signed_idx + rel_x;
-                let y = signed_idx + rel_y;
+                let x: usize = (signed_idx + rel_x).try_into().ok()?;
+                let y: usize = (signed_idx + rel_y).try_into().ok()?;
 
-                // this should be made safe.
-                Opcode::Split(InstSplit::new(
-                    InstIndex::from(x as usize),
-                    InstIndex::from(y as usize),
-                ))
+                Some(Opcode::Split(InstSplit::new(
+                    InstIndex::from(x),
+                    InstIndex::from(y),
+                )))
             }
             RelativeOpcode::Jmp(rel_jmp_to) => {
                 let signed_idx = idx as isize;
-                let jmp_to = signed_idx + rel_jmp_to;
+                let jmp_to: usize = (signed_idx + rel_jmp_to).try_into().ok()?;
 
-                // this should be made safe.
-                Opcode::Jmp(InstJmp::new(InstIndex::from(jmp_to as usize)))
+                Some(Opcode::Jmp(InstJmp::new(InstIndex::from(jmp_to))))
             }
-            RelativeOpcode::StartSave(slot) => Opcode::StartSave(InstStartSave::new(*slot)),
-            RelativeOpcode::EndSave(slot) => Opcode::EndSave(InstEndSave::new(*slot)),
-            RelativeOpcode::Match => Opcode::Match,
+            RelativeOpcode::StartSave(slot) => Some(Opcode::StartSave(InstStartSave::new(*slot))),
+            RelativeOpcode::EndSave(slot) => Some(Opcode::EndSave(InstEndSave::new(*slot))),
+            RelativeOpcode::Match => Some(Opcode::Match),
         }
+    }
+
+    fn to_opcode_with_index_unchecked(&self, idx: usize) -> Opcode {
+        self.to_opcode_with_index(idx).unwrap()
     }
 }
 

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -14,7 +14,7 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
             let prefix = [
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
             ];
 
             prefix
@@ -103,7 +103,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                 Opcode::Consume(InstConsume::new('a')),
                 Opcode::Consume(InstConsume::new('b')),
                 Opcode::Match,
@@ -153,7 +153,7 @@ mod tests {
             Ok(Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                 Opcode::Any,
                 Opcode::Match,
             ])),

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -8,6 +8,7 @@ use relex_runtime::*;
 /// This type is meant to exist only internally and should be
 /// refined to the `relex_runtime::Opcode type
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 enum RelativeOpcode {
     Any,
     Consume(char),
@@ -132,6 +133,7 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
         } => {
             let min_match = vec![RelativeOpcode::Any; cnt as usize];
             let optional = vec![
+                // looping match case first (1) signifies eager consumption
                 RelativeOpcode::Split(1, 3),
                 RelativeOpcode::Any,
                 RelativeOpcode::Jmp(-2),
@@ -146,6 +148,7 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
         } => {
             let min_match = vec![RelativeOpcode::Consume(c); cnt as usize];
             let optional = vec![
+                // looping match case first (1) signifies eager consumption
                 RelativeOpcode::Split(1, 3),
                 RelativeOpcode::Consume(c),
                 RelativeOpcode::Jmp(-2),

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -567,6 +567,23 @@ mod tests {
                 parse(&input)
             )
         }
+
+        // test single character matches
+        let inputs = vec![(QuantifierType::MatchExactRange(Integer(2)), "^a{2}")];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                        quantifier: Quantifier::Eager(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
     }
 
     #[test]

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -537,6 +537,39 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_eager_repetition_quantifiers() {
+        use ast::*;
+
+        let inputs = vec![
+            (QuantifierType::OneOrMore, "^.+"),
+            (QuantifierType::ZeroOrMore, "^.*"),
+            (QuantifierType::MatchExactRange(Integer(2)), "^.{2}"),
+            (QuantifierType::MatchAtleastRange(Integer(2)), "^.{2,}"),
+            (
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                },
+                "^.{2,4}",
+            ),
+        ];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchAnyCharacter,
+                        quantifier: Quantifier::Eager(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
+    }
+
+    #[test]
     fn should_parse_any_match() {
         use ast::*;
         let input = ".".chars().enumerate().collect::<Vec<(usize, char)>>();

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -544,7 +544,7 @@ mod tests {
             (QuantifierType::OneOrMore, "^.+"),
             (QuantifierType::ZeroOrMore, "^.*"),
             (QuantifierType::MatchExactRange(Integer(2)), "^.{2}"),
-            (QuantifierType::MatchAtleastRange(Integer(2)), "^.{2,}"),
+            (QuantifierType::MatchAtLeastRange(Integer(2)), "^.{2,}"),
             (
                 QuantifierType::MatchBetweenRange {
                     lower_bound: Integer(2),

--- a/runtime/benches/exponential.rs
+++ b/runtime/benches/exponential.rs
@@ -37,7 +37,7 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
                         let prog = Instructions::new(vec![
                             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                             Opcode::Any,
-                            Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                            Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                             Opcode::StartSave(InstStartSave::new(0)),
                             Opcode::Consume(InstConsume::new('a')),
                             Opcode::Consume(InstConsume::new('b')),

--- a/runtime/benches/exponential.rs
+++ b/runtime/benches/exponential.rs
@@ -37,7 +37,7 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
                         let prog = Instructions::new(vec![
                             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                             Opcode::Any,
-                            Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                            Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                             Opcode::StartSave(InstStartSave::new(0)),
                             Opcode::Consume(InstConsume::new('a')),
                             Opcode::Consume(InstConsume::new('b')),

--- a/runtime/benches/exponential.rs
+++ b/runtime/benches/exponential.rs
@@ -37,7 +37,7 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
                         let prog = Instructions::new(vec![
                             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                             Opcode::Any,
-                            Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                            Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                             Opcode::StartSave(InstStartSave::new(0)),
                             Opcode::Consume(InstConsume::new('a')),
                             Opcode::Consume(InstConsume::new('b')),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -701,6 +701,30 @@ mod tests {
     }
 
     #[test]
+    fn should_evaluate_quantifier_expression() {
+        let tests = vec![
+            (vec![SaveGroupSlot::complete(0, 0, 2)], "aab"),
+            // (vec![SaveGroupSlot::complete(0, 0, 3)], "aaab"),
+        ];
+
+        let prog = Instructions::new(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(4))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog.program, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
     fn should_print_test_instructions() {
         let prog = Instructions::new(vec![
             Opcode::Consume(InstConsume::new('a')),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -701,7 +701,28 @@ mod tests {
     }
 
     #[test]
-    fn should_evaluate_quantifier_expression() {
+    fn should_evaluate_eager_match_exact_quantifier_expression() {
+        let tests = vec![
+            (vec![SaveGroupSlot::complete(0, 0, 2)], "aab"),
+            (vec![SaveGroupSlot::complete(0, 0, 2)], "aaab"),
+        ];
+
+        let prog = Instructions::new(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog.program, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_match_atleast_quantifier_expression() {
         let tests = vec![
             (vec![SaveGroupSlot::complete(0, 0, 2)], "aab"),
             (vec![SaveGroupSlot::complete(0, 0, 3)], "aaab"),
@@ -714,6 +735,33 @@ mod tests {
             Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(6))),
             Opcode::Consume(InstConsume::new('a')),
             Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog.program, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    #[ignore = "unimplemented"]
+    fn should_evaluate_eager_match_between_quantifier_expression() {
+        let tests = vec![
+            (vec![SaveGroupSlot::complete(0, 0, 2)], "aab"),
+            (vec![SaveGroupSlot::complete(0, 0, 3)], "aaab"),
+            (vec![SaveGroupSlot::complete(0, 0, 4)], "aaaab"),
+        ];
+
+        let prog = Instructions::new(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(7))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(7))),
+            Opcode::Consume(InstConsume::new('a')),
             Opcode::EndSave(InstEndSave::new(0)),
             Opcode::Match,
         ]);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,8 @@ pub enum Opcode {
     Any,
     Consume(InstConsume),
     Split(InstSplit),
-    JmpAbs(InstJmp),
+    JmpAbs(InstJmpAbs),
+    JmpRel(InstJmpRel),
     StartSave(InstStartSave),
     EndSave(InstEndSave),
     Match,
@@ -256,6 +257,7 @@ impl Display for Opcode {
             Opcode::Split(i) => std::fmt::Display::fmt(&i, f),
             Opcode::Any => std::fmt::Display::fmt(&InstAny::new(), f),
             Opcode::JmpAbs(i) => std::fmt::Display::fmt(&i, f),
+            Opcode::JmpRel(i) => std::fmt::Display::fmt(&i, f),
             Opcode::StartSave(i) => std::fmt::Display::fmt(&i, f),
             Opcode::EndSave(i) => std::fmt::Display::fmt(&i, f),
         }
@@ -338,19 +340,36 @@ impl Display for InstSplit {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct InstJmp {
+pub struct InstJmpAbs {
     next: InstIndex,
 }
 
-impl InstJmp {
+impl InstJmpAbs {
     pub fn new(next: InstIndex) -> Self {
         Self { next }
     }
 }
 
-impl Display for InstJmp {
+impl Display for InstJmpAbs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Jump: ({:04})", self.next.as_usize())
+        write!(f, "JumpAbs: ({:04})", self.next.as_usize())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstJmpRel {
+    next: isize,
+}
+
+impl InstJmpRel {
+    pub fn new(next: isize) -> Self {
+        Self { next }
+    }
+}
+
+impl Display for InstJmpRel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JumpRel: ({:04})", self.next)
     }
 }
 
@@ -441,7 +460,7 @@ fn add_thread(
                 input,
             )
         }
-        Opcode::JmpAbs(InstJmp { next }) => add_thread(
+        Opcode::JmpAbs(InstJmpAbs { next }) => add_thread(
             program,
             save_groups,
             thread_list,
@@ -638,7 +657,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                    Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('a')),
@@ -651,7 +670,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                    Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('b')),
@@ -679,7 +698,7 @@ mod tests {
             Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
                 Opcode::Split(InstSplit::new(InstIndex::from(9), InstIndex::from(4))),
                 Opcode::StartSave(InstStartSave::new(0)),
                 Opcode::Consume(InstConsume::new('a')),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,8 +242,7 @@ pub enum Opcode {
     Any,
     Consume(InstConsume),
     Split(InstSplit),
-    JmpAbs(InstJmpAbs),
-    JmpRel(InstJmpRel),
+    Jmp(InstJmp),
     StartSave(InstStartSave),
     EndSave(InstEndSave),
     Match,
@@ -256,8 +255,7 @@ impl Display for Opcode {
             Opcode::Consume(i) => std::fmt::Display::fmt(&i, f),
             Opcode::Split(i) => std::fmt::Display::fmt(&i, f),
             Opcode::Any => std::fmt::Display::fmt(&InstAny::new(), f),
-            Opcode::JmpAbs(i) => std::fmt::Display::fmt(&i, f),
-            Opcode::JmpRel(i) => std::fmt::Display::fmt(&i, f),
+            Opcode::Jmp(i) => std::fmt::Display::fmt(&i, f),
             Opcode::StartSave(i) => std::fmt::Display::fmt(&i, f),
             Opcode::EndSave(i) => std::fmt::Display::fmt(&i, f),
         }
@@ -340,36 +338,19 @@ impl Display for InstSplit {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct InstJmpAbs {
+pub struct InstJmp {
     next: InstIndex,
 }
 
-impl InstJmpAbs {
+impl InstJmp {
     pub fn new(next: InstIndex) -> Self {
         Self { next }
     }
 }
 
-impl Display for InstJmpAbs {
+impl Display for InstJmp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JumpAbs: ({:04})", self.next.as_usize())
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct InstJmpRel {
-    next: isize,
-}
-
-impl InstJmpRel {
-    pub fn new(next: isize) -> Self {
-        Self { next }
-    }
-}
-
-impl Display for InstJmpRel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "JumpRel: ({:04})", self.next)
     }
 }
 
@@ -460,7 +441,7 @@ fn add_thread(
                 input,
             )
         }
-        Opcode::JmpAbs(InstJmpAbs { next }) => add_thread(
+        Opcode::Jmp(InstJmp { next }) => add_thread(
             program,
             save_groups,
             thread_list,
@@ -657,7 +638,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('a')),
@@ -670,7 +651,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('b')),
@@ -698,7 +679,7 @@ mod tests {
             Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::JmpAbs(InstJmpAbs::new(InstIndex::from(0))),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                 Opcode::Split(InstSplit::new(InstIndex::from(9), InstIndex::from(4))),
                 Opcode::StartSave(InstStartSave::new(0)),
                 Opcode::Consume(InstConsume::new('a')),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,7 @@ pub enum Opcode {
     Any,
     Consume(InstConsume),
     Split(InstSplit),
-    Jmp(InstJmp),
+    JmpAbs(InstJmp),
     StartSave(InstStartSave),
     EndSave(InstEndSave),
     Match,
@@ -255,7 +255,7 @@ impl Display for Opcode {
             Opcode::Consume(i) => std::fmt::Display::fmt(&i, f),
             Opcode::Split(i) => std::fmt::Display::fmt(&i, f),
             Opcode::Any => std::fmt::Display::fmt(&InstAny::new(), f),
-            Opcode::Jmp(i) => std::fmt::Display::fmt(&i, f),
+            Opcode::JmpAbs(i) => std::fmt::Display::fmt(&i, f),
             Opcode::StartSave(i) => std::fmt::Display::fmt(&i, f),
             Opcode::EndSave(i) => std::fmt::Display::fmt(&i, f),
         }
@@ -441,7 +441,7 @@ fn add_thread(
                 input,
             )
         }
-        Opcode::Jmp(InstJmp { next }) => add_thread(
+        Opcode::JmpAbs(InstJmp { next }) => add_thread(
             program,
             save_groups,
             thread_list,
@@ -638,7 +638,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('a')),
@@ -651,7 +651,7 @@ mod tests {
                 Instructions::new(vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::Any,
-                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                     Opcode::StartSave(InstStartSave::new(0)),
                     Opcode::Consume(InstConsume::new('a')),
                     Opcode::Consume(InstConsume::new('b')),
@@ -679,7 +679,7 @@ mod tests {
             Instructions::new(vec![
                 Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                 Opcode::Any,
-                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::JmpAbs(InstJmp::new(InstIndex::from(0))),
                 Opcode::Split(InstSplit::new(InstIndex::from(9), InstIndex::from(4))),
                 Opcode::StartSave(InstStartSave::new(0)),
                 Opcode::Consume(InstConsume::new('a')),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -704,14 +704,14 @@ mod tests {
     fn should_evaluate_quantifier_expression() {
         let tests = vec![
             (vec![SaveGroupSlot::complete(0, 0, 2)], "aab"),
-            // (vec![SaveGroupSlot::complete(0, 0, 3)], "aaab"),
+            (vec![SaveGroupSlot::complete(0, 0, 3)], "aaab"),
         ];
 
         let prog = Instructions::new(vec![
             Opcode::StartSave(InstStartSave::new(0)),
             Opcode::Consume(InstConsume::new('a')),
             Opcode::Consume(InstConsume::new('a')),
-            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(4))),
+            Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(6))),
             Opcode::Consume(InstConsume::new('a')),
             Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
             Opcode::EndSave(InstEndSave::new(0)),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -237,7 +237,7 @@ impl Display for Instruction {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Opcode {
     Any,
     Consume(InstConsume),
@@ -292,7 +292,7 @@ impl Display for InstAny {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InstConsume {
     value: char,
 }
@@ -310,7 +310,7 @@ impl Display for InstConsume {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InstSplit {
     x_branch: InstIndex,
     y_branch: InstIndex,
@@ -337,7 +337,7 @@ impl Display for InstSplit {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InstJmp {
     next: InstIndex,
 }
@@ -354,7 +354,7 @@ impl Display for InstJmp {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InstStartSave {
     slot_id: usize,
 }
@@ -372,7 +372,7 @@ impl Display for InstStartSave {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InstEndSave {
     slot_id: usize,
 }


### PR DESCRIPTION
# Introduction
This PR begins implementing quantifiers for the `MatchItem` grammar element.

- `^a{2}`
- `^a{2,}`

## TODO
- `^a{2,4}`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
