### PR TITLE
Initial character range implementation without quantifiers

### DIFF
--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -62,7 +62,7 @@ CharacterClassAnyDecimalDigitInverted ::= "\D"
 CharacterClassFromUnicodeCategory ::= "\p{" UnicodeCategoryName "}"
 UnicodeCategoryName ::= Letters
 
-CharacterRange ::= Char ("-" Char)?
+CharacterRange ::= Char "-" Char
 
 
 /* Quantifiers 

--- a/docs/grammar.xhtml
+++ b/docs/grammar.xhtml
@@ -934,7 +934,7 @@
          <xhtml:ul>
             <xhtml:li><xhtml:a href="#CharacterClassFromUnicodeCategory" title="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory</xhtml:a></xhtml:li>
          </xhtml:ul>
-      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterRange">CharacterRange:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="265" height="69">
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterRange">CharacterRange:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="225" height="37">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -968,17 +968,17 @@
          <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
             <rect x="31" y="3" width="50" height="32"></rect>
             <rect x="29" y="1" width="50" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">Char</text></a><rect x="121" y="35" width="26" height="32" rx="10"></rect>
-         <rect x="119" y="33" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="129" y="53">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
-            <rect x="167" y="35" width="50" height="32"></rect>
-            <rect x="165" y="33" width="50" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="175" y="53">Char</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m50 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m26 0 h10 m0 0 h10 m50 0 h10 m23 -32 h-3"></svg:path>
-         <polygon points="255 17 263 13 263 21"></polygon>
-         <polygon points="255 17 247 13 247 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+            <text class="nonterminal" x="39" y="21">Char</text></a><rect x="101" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="99" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="109" y="21">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
+            <rect x="147" y="3" width="50" height="32"></rect>
+            <rect x="145" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="21">Char</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m50 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="215 17 223 13 223 21"></polygon>
+         <polygon points="215 17 207 13 207 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
          <xhtml:div class="ebnf"><xhtml:code>
                <div><a href="#CharacterRange" title="CharacterRange">CharacterRange</a></div>
-               <div>         ::= <a href="#Char" title="Char">Char</a> ( '-' <a href="#Char" title="Char">Char</a> )?</div></xhtml:code></xhtml:div>
+               <div>         ::= <a href="#Char" title="Char">Char</a> '-' <a href="#Char" title="Char">Char</a></div></xhtml:code></xhtml:div>
       </xhtml:p>
       <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
          <xhtml:ul>

--- a/relex/src/ast.rs
+++ b/relex/src/ast.rs
@@ -172,8 +172,7 @@ pub struct CharacterGroupNegativeModifier;
 pub enum CharacterGroupItem {
     CharacterClass(CharacterClass),
     CharacterClassFromUnicodeCategory(UnicodeCategoryName),
-    CharacterRangeWithUpperBound(Char, Char),
-    CharacterRange(Char),
+    CharacterRange(Char, Char),
     Char(Char),
 }
 
@@ -198,10 +197,7 @@ impl From<CharacterRange> for CharacterGroupItem {
             upper_bound,
         } = src;
 
-        match (lower_bound, upper_bound) {
-            (lower, Some(upper)) => Self::CharacterRangeWithUpperBound(lower, upper),
-            (lower, None) => Self::CharacterRange(lower),
-        }
+        Self::CharacterRange(lower_bound, upper_bound)
     }
 }
 
@@ -271,11 +267,11 @@ pub struct UnicodeCategoryName(pub Letters);
 
 pub struct CharacterRange {
     lower_bound: Char,
-    upper_bound: Option<Char>,
+    upper_bound: Char,
 }
 
 impl CharacterRange {
-    pub fn new(lower_bound: Char, upper_bound: Option<Char>) -> Self {
+    pub fn new(lower_bound: Char, upper_bound: Char) -> Self {
         Self {
             lower_bound,
             upper_bound,

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -443,12 +443,9 @@ fn character_group_item_to_set(cgi: ast::CharacterGroupItem) -> CharacterSet {
     match cgi {
         ast::CharacterGroupItem::CharacterClassFromUnicodeCategory(_) => unimplemented!(),
         ast::CharacterGroupItem::CharacterClass(cc) => character_class_to_set(cc),
-        ast::CharacterGroupItem::CharacterRangeWithUpperBound(Char(lower), Char(upper)) => {
+        ast::CharacterGroupItem::CharacterRange(Char(lower), Char(upper)) => {
             let alphabet = CharacterAlphabet::Range(lower..=upper);
             CharacterSet::inclusive(alphabet)
-        }
-        ast::CharacterGroupItem::CharacterRange(Char(c)) => {
-            CharacterSet::inclusive(CharacterAlphabet::Explicit(vec![c]))
         }
         ast::CharacterGroupItem::Char(Char(c)) => {
             CharacterSet::inclusive(CharacterAlphabet::Explicit(vec![c]))
@@ -1039,7 +1036,7 @@ mod tests {
         let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
             SubExpressionItem::Match(Match::WithoutQuantifier {
                 item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
-                    CharacterGroup::Items(vec![CharacterGroupItem::CharacterRangeWithUpperBound(
+                    CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
                         Char('0'),
                         Char('9'),
                     )]),

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -109,65 +109,13 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
 
 fn expression(expr: ast::Expression) -> Result<RelativeOpcodes, String> {
     let ast::Expression(subexprs) = expr;
-    let subexpr_cnt = subexprs.len();
 
     let compiled_subexprs = subexprs
         .into_iter()
         .map(subexpression)
         .collect::<Result<Vec<_>, _>>()?;
 
-    let length_of_each_subexpr: Vec<_> = compiled_subexprs
-        .iter()
-        .enumerate()
-        .map(|(idx, subexpr)| ((idx + 1 == subexpr_cnt), subexpr))
-        .map(|(is_last, subexpr)| {
-            // last alternation doesn't require a split prefix and jump suffix
-            if is_last {
-                subexpr.len()
-            } else {
-                subexpr.len() + 2
-            }
-        })
-        .collect();
-
-    let total_length_of_compiled_expr: usize = length_of_each_subexpr.iter().sum();
-    let start_end_offsets_by_subexpr: Vec<(usize, usize)> = length_of_each_subexpr
-        .iter()
-        .fold(
-            // add 1 to set end at first instruction of next expr
-            (total_length_of_compiled_expr + 1, vec![]),
-            |(offset_to_end, mut acc), &subexpr_len| {
-                let new_offset_to_end = offset_to_end - subexpr_len;
-
-                acc.push((subexpr_len, new_offset_to_end));
-                (new_offset_to_end, acc)
-            },
-        )
-        .1;
-
-    let compiled_subexpressions_with_applied_alternations = compiled_subexprs
-        .into_iter()
-        .zip(start_end_offsets_by_subexpr.into_iter())
-        .enumerate()
-        .map(|(idx, (opcodes, start_end_offsets))| {
-            let optional_next_offsets = ((idx + 1) != subexpr_cnt)
-                .then(|| start_end_offsets)
-                .map(|(start, end)| (start as isize, end as isize));
-            (optional_next_offsets, opcodes)
-        })
-        .flat_map(|(start_of_next, ops)| match start_of_next {
-            Some((start_of_next_subexpr_offset, end_of_expr_offset)) => {
-                [RelativeOpcode::Split(1, start_of_next_subexpr_offset)]
-                    .into_iter()
-                    .chain(ops.into_iter())
-                    .chain([RelativeOpcode::Jmp(end_of_expr_offset)].into_iter())
-                    .collect()
-            }
-            None => ops,
-        })
-        .collect();
-
-    Ok(compiled_subexpressions_with_applied_alternations)
+    alternations_for_supplied_relative_opcodes(compiled_subexprs)
 }
 
 fn subexpression(subexpr: ast::SubExpression) -> Result<RelativeOpcodes, String> {
@@ -571,6 +519,66 @@ fn character_class_to_set(cc: ast::CharacterClass) -> CharacterSet {
         ast::CharacterClass::AnyDecimalDigit => AnyDecimalDigitClass.into(),
         ast::CharacterClass::AnyDecimalDigitInverted => AnyDecimalDigitClassInverted.into(),
     }
+}
+
+/// Generates alternations from a block of relative operations.
+fn alternations_for_supplied_relative_opcodes(
+    rel_ops: Vec<RelativeOpcodes>,
+) -> Result<RelativeOpcodes, String> {
+    let subexpr_cnt = rel_ops.len();
+
+    let length_of_rel_ops: Vec<_> = rel_ops
+        .iter()
+        .enumerate()
+        .map(|(idx, subexpr)| ((idx + 1 == subexpr_cnt), subexpr))
+        .map(|(is_last, subexpr)| {
+            // last alternation doesn't require a split prefix and jump suffix
+            if is_last {
+                subexpr.len()
+            } else {
+                subexpr.len() + 2
+            }
+        })
+        .collect();
+
+    let total_length_of_compiled_expr: usize = length_of_rel_ops.iter().sum();
+    let start_end_offsets_by_subexpr: Vec<(usize, usize)> = length_of_rel_ops
+        .iter()
+        .fold(
+            // add 1 to set end at first instruction of next expr
+            (total_length_of_compiled_expr + 1, vec![]),
+            |(offset_to_end, mut acc), &subexpr_len| {
+                let new_offset_to_end = offset_to_end - subexpr_len;
+
+                acc.push((subexpr_len, new_offset_to_end));
+                (new_offset_to_end, acc)
+            },
+        )
+        .1;
+
+    let compiled_ops_with_applied_alternations = rel_ops
+        .into_iter()
+        .zip(start_end_offsets_by_subexpr.into_iter())
+        .enumerate()
+        .map(|(idx, (opcodes, start_end_offsets))| {
+            let optional_next_offsets = ((idx + 1) != subexpr_cnt)
+                .then(|| start_end_offsets)
+                .map(|(start, end)| (start as isize, end as isize));
+            (optional_next_offsets, opcodes)
+        })
+        .flat_map(|(start_of_next, ops)| match start_of_next {
+            Some((start_of_next_subexpr_offset, end_of_expr_offset)) => {
+                [RelativeOpcode::Split(1, start_of_next_subexpr_offset)]
+                    .into_iter()
+                    .chain(ops.into_iter())
+                    .chain([RelativeOpcode::Jmp(end_of_expr_offset)].into_iter())
+                    .collect()
+            }
+            None => ops,
+        })
+        .collect();
+
+    Ok(compiled_ops_with_applied_alternations)
 }
 
 #[cfg(test)]

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -680,6 +680,15 @@ mod tests {
                     Char('z'),
                 )]),
             ),
+            (
+                "^[abc0-9]",
+                CharacterGroup::Items(vec![
+                    CharacterGroupItem::Char(Char('a')),
+                    CharacterGroupItem::Char(Char('b')),
+                    CharacterGroupItem::Char(Char('c')),
+                    CharacterGroupItem::CharacterRange(Char('0'), Char('9')),
+                ]),
+            ),
         ];
 
         for (test_id, (input, output)) in input_output.into_iter().enumerate() {

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -673,6 +673,13 @@ mod tests {
                     CharacterGroupItem::Char(Char('b')),
                 ]),
             ),
+            (
+                "^[a-z]",
+                CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
+                    Char('a'),
+                    Char('z'),
+                )]),
+            ),
         ];
 
         for (test_id, (input, output)) in input_output.into_iter().enumerate() {

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -122,8 +122,8 @@ fn r#match<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Match> {
 }
 
 fn match_item<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::MatchItem> {
-    parcel::or(match_any_character().map(Into::into), || {
-        parcel::or(match_character_class().map(Into::into), || {
+    parcel::or(match_character_class().map(Into::into), || {
+        parcel::or(match_any_character().map(Into::into), || {
             match_character().map(Into::into)
         })
     })
@@ -161,12 +161,15 @@ fn match_character<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Ma
 fn character_group<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterGroup> {
     parcel::join(
         parcel::right(parcel::join(
-            expect_character('['),
+            expect_character('[').map(|c| c),
             parcel::optional(character_group_negative_modifier())
                 .map(|negation| negation.is_some()),
         )),
         parcel::left(parcel::join(
-            parcel::one_or_more(character_group_item()),
+            parcel::one_or_more(character_group_item()).map(|gis| {
+                println!("Reach {:?}", &gis);
+                gis
+            }),
             expect_character(']'),
         )),
     )
@@ -178,7 +181,7 @@ fn character_group<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Ch
 
 fn character_group_negative_modifier<'a>(
 ) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterGroupNegativeModifier> {
-    parcel::optional(expect_character('^')).map(|_| ast::CharacterGroupNegativeModifier)
+    expect_character('^').map(|_| ast::CharacterGroupNegativeModifier)
 }
 
 fn character_group_item<'a>(
@@ -186,7 +189,11 @@ fn character_group_item<'a>(
     parcel::or(character_class().map(Into::into), || {
         parcel::or(
             character_class_from_unicode_category().map(Into::into),
-            || parcel::or(character_range().map(Into::into), || char().map(Into::into)),
+            || {
+                parcel::or(character_range().map(Into::into), || {
+                    char().predicate(|ast::Char(c)| *c != ']').map(Into::into)
+                })
+            },
         )
     })
 }
@@ -244,7 +251,7 @@ fn unicode_category_name<'a>(
 fn character_range<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterRange> {
     parcel::join(
         char(),
-        parcel::optional(parcel::right(parcel::join(expect_character('-'), char()))),
+        parcel::right(parcel::join(expect_character('-'), char())),
     )
     .map(|(lower_bound, upper_bound)| ast::CharacterRange::new(lower_bound, upper_bound))
 }
@@ -650,6 +657,34 @@ mod tests {
                     })])
                 ]))),
                 parse(&input)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_character_group_items() {
+        use ast::*;
+        let input_output = vec![(
+            "^[a]",
+            CharacterGroup::Items(vec![CharacterGroupItem::Char(Char('a'))]),
+        )];
+
+        for (test_id, (input, output)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                            item: MatchItem::MatchCharacterClass(
+                                MatchCharacterClass::CharacterGroup(output)
+                            )
+                        }),])
+                    ])))
+                ),
+                (test_id, res)
             )
         }
     }

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -166,10 +166,7 @@ fn character_group<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Ch
                 .map(|negation| negation.is_some()),
         )),
         parcel::left(parcel::join(
-            parcel::one_or_more(character_group_item()).map(|gis| {
-                println!("Reach {:?}", &gis);
-                gis
-            }),
+            parcel::one_or_more(character_group_item()),
             expect_character(']'),
         )),
     )
@@ -664,10 +661,19 @@ mod tests {
     #[test]
     fn should_parse_character_group_items() {
         use ast::*;
-        let input_output = vec![(
-            "^[a]",
-            CharacterGroup::Items(vec![CharacterGroupItem::Char(Char('a'))]),
-        )];
+        let input_output = vec![
+            (
+                "^[a]",
+                CharacterGroup::Items(vec![CharacterGroupItem::Char(Char('a'))]),
+            ),
+            (
+                "^[ab]",
+                CharacterGroup::Items(vec![
+                    CharacterGroupItem::Char(Char('a')),
+                    CharacterGroupItem::Char(Char('b')),
+                ]),
+            ),
+        ];
 
         for (test_id, (input, output)) in input_output.into_iter().enumerate() {
             let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();

--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -61,12 +61,9 @@ pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
     let pad = "xy";
 
     let prog = Instructions::default()
-        .with_sets(vec![CharacterSet::Ranges(vec![
-            'a'..='z',
-            'A'..='Z',
-            '0'..='9',
-            '_'..='_',
-        ])])
+        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
+            vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'],
+        ))])
         .with_opcodes(vec![
             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
             Opcode::Any,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -378,6 +378,9 @@ impl<CRSV: CharacterRangeSetVerifiable> CharacterRangeSetVerifiable for Vec<CRSV
     }
 }
 
+/// Defines that a given type can be converted into a character set.
+pub trait CharacterSetRepresentable: Into<CharacterSet> {}
+
 /// Representing a runtime-dispatchable set of characters by associating a sets
 /// membership to a character alphabet.
 #[derive(Debug, Clone, PartialEq)]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -378,9 +378,54 @@ impl<CRSV: CharacterRangeSetVerifiable> CharacterRangeSetVerifiable for Vec<CRSV
     }
 }
 
-/// Represents a runtime dispatchable type for character sets.
+/// Representing a runtime-dispatchable set of characters by associating a sets
+/// membership to a character alphabet.
 #[derive(Debug, Clone, PartialEq)]
-pub enum CharacterSet {
+pub struct CharacterSet {
+    membership: SetMembership,
+    set: CharacterAlphabet,
+}
+
+impl CharacterSet {
+    pub fn inclusive(set: CharacterAlphabet) -> Self {
+        Self {
+            membership: SetMembership::Inclusive,
+            set,
+        }
+    }
+
+    pub fn exclusive(set: CharacterAlphabet) -> Self {
+        Self {
+            membership: SetMembership::Exclusive,
+            set,
+        }
+    }
+
+    pub fn invert_membership(self) -> Self {
+        let Self { membership, set } = self;
+
+        Self {
+            membership: match membership {
+                SetMembership::Inclusive => SetMembership::Exclusive,
+                SetMembership::Exclusive => SetMembership::Inclusive,
+            },
+            set,
+        }
+    }
+}
+
+impl CharacterRangeSetVerifiable for CharacterSet {
+    fn in_set(&self, value: char) -> bool {
+        match &self.membership {
+            SetMembership::Inclusive => self.set.in_set(value),
+            SetMembership::Exclusive => self.set.not_in_set(value),
+        }
+    }
+}
+
+/// Represents a runtime dispatchable set of characters.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CharacterAlphabet {
     /// Represents a range of values i.e. `0-9`, `a-z`, `A-Z`, etc...
     Range(std::ops::RangeInclusive<char>),
     /// Represents an explicitly defined set of values. i.e. `[a,b,z]`, `[1,2,7]`
@@ -389,12 +434,30 @@ pub enum CharacterSet {
     Ranges(Vec<std::ops::RangeInclusive<char>>),
 }
 
-impl CharacterRangeSetVerifiable for CharacterSet {
+impl CharacterAlphabet {
+    /// Joins a group of character sets into a single `Ranges` variant character set.
+    pub fn join(sets: Vec<Self>) -> CharacterAlphabet {
+        let ranges = sets
+            .into_iter()
+            .flat_map(|set| match set {
+                CharacterAlphabet::Range(r) => vec![r],
+                CharacterAlphabet::Ranges(ranges) => ranges,
+                CharacterAlphabet::Explicit(explicit_chars) => {
+                    explicit_chars.into_iter().map(|c| c..=c).collect()
+                }
+            })
+            .collect();
+
+        CharacterAlphabet::Ranges(ranges)
+    }
+}
+
+impl CharacterRangeSetVerifiable for CharacterAlphabet {
     fn in_set(&self, value: char) -> bool {
         match self {
-            CharacterSet::Range(r) => r.in_set(value),
-            CharacterSet::Explicit(v) => v.in_set(value),
-            CharacterSet::Ranges(ranges) => ranges.in_set(value),
+            CharacterAlphabet::Range(r) => r.in_set(value),
+            CharacterAlphabet::Explicit(v) => v.in_set(value),
+            CharacterAlphabet::Ranges(ranges) => ranges.in_set(value),
         }
     }
 }
@@ -415,25 +478,13 @@ pub enum SetMembership {
 /// characters. This functions as a brevity tool to prevent long alternations.
 #[derive(Debug, Clone, PartialEq)]
 pub struct InstConsumeSet {
-    pub membership: SetMembership,
     pub idx: usize,
 }
 
 impl InstConsumeSet {
     #[must_use]
     pub fn member_of(idx: usize) -> Self {
-        Self {
-            membership: SetMembership::Inclusive,
-            idx,
-        }
-    }
-
-    #[must_use]
-    pub fn exclusive(idx: usize) -> Self {
-        Self {
-            membership: SetMembership::Exclusive,
-            idx,
-        }
+        Self { idx }
     }
 }
 
@@ -705,17 +756,10 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<Vec<S
                     continue;
                 }
 
-                Some(Opcode::ConsumeSet(InstConsumeSet {
-                    membership: inclusivity,
-                    idx: set_idx,
-                })) if next_char.map_or(false, |c| match inclusivity {
-                    SetMembership::Inclusive => {
+                Some(Opcode::ConsumeSet(InstConsumeSet { idx: set_idx }))
+                    if next_char.map_or(false, |c| {
                         sets.get(*set_idx).map_or(false, |set| set.in_set(c))
-                    }
-                    SetMembership::Exclusive => {
-                        sets.get(*set_idx).map_or(false, |set| set.not_in_set(c))
-                    }
-                }) =>
+                    }) =>
                 {
                     let thread_local_save_group =
                         if let SaveGroup::Allocated { slot_id } = save_group {
@@ -832,35 +876,39 @@ mod tests {
         let progs = vec![
             (
                 Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
-                Opcode::ConsumeSet(InstConsumeSet::member_of(2)),
-            ),
-            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(3))),
-            (
-                Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
-                Opcode::ConsumeSet(InstConsumeSet::exclusive(3)),
-            ),
-            (None, Opcode::ConsumeSet(InstConsumeSet::exclusive(2))),
-            (
-                Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
                 Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
             ),
             (None, Opcode::ConsumeSet(InstConsumeSet::member_of(1))),
             (
                 Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
-                Opcode::ConsumeSet(InstConsumeSet::exclusive(1)),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(3)),
             ),
-            (None, Opcode::ConsumeSet(InstConsumeSet::exclusive(0))),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(2))),
+            (
+                Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(4)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(5))),
+            (
+                Some(vec![SaveGroupSlot::complete(0, 0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(7)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(6))),
         ];
 
         let input = "aab";
 
-        for (expected_res, consume_set_inst) in progs {
+        for (test_id, (expected_res, consume_set_inst)) in progs.into_iter().enumerate() {
             let prog = Instructions::default()
                 .with_sets(vec![
-                    CharacterSet::Explicit(vec!['a', 'b']),
-                    CharacterSet::Explicit(vec!['x', 'y', 'z']),
-                    CharacterSet::Range('a'..='z'),
-                    CharacterSet::Range('x'..='z'),
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['a', 'b'])),
+                    CharacterSet::exclusive(CharacterAlphabet::Explicit(vec!['a', 'b'])),
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['x', 'y', 'z'])),
+                    CharacterSet::exclusive(CharacterAlphabet::Explicit(vec!['x', 'y', 'z'])),
+                    CharacterSet::inclusive(CharacterAlphabet::Range('a'..='z')),
+                    CharacterSet::exclusive(CharacterAlphabet::Range('a'..='z')),
+                    CharacterSet::inclusive(CharacterAlphabet::Range('x'..='z')),
+                    CharacterSet::exclusive(CharacterAlphabet::Range('x'..='z')),
                 ])
                 .with_opcodes(vec![
                     Opcode::StartSave(InstStartSave::new(0)),
@@ -869,7 +917,7 @@ mod tests {
                     Opcode::Match,
                 ]);
             let res = run::<1>(&prog, input);
-            assert_eq!(expected_res, res)
+            assert_eq!((test_id, expected_res), (test_id, res))
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -485,7 +485,10 @@ pub struct InstConsumeSet {
 }
 
 impl InstConsumeSet {
-    #[must_use]
+    pub fn new(idx: usize) -> Self {
+        Self::member_of(idx)
+    }
+
     pub fn member_of(idx: usize) -> Self {
         Self { idx }
     }


### PR DESCRIPTION
# Introduction
This is a first pass character range implementation for matches without quantifiers.

- `^[abc]`
- `^[0-9]`
- `^[abc0-9]`

# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
