### PR TITLE
Add quantifiers for character classes

### DIFF
--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -143,7 +143,7 @@ macro_rules! generate_range_quantifier_block {
             .into_iter()
             // jump past end of expression
             .chain(vec![RelativeOpcode::Split(1, (($consumer.len() + 2) as isize))].into_iter())
-            .chain($consumer.into_iter())
+            .chain($consumer.clone().into_iter())
             // return to split
             .chain(vec![RelativeOpcode::Jmp(-($consumer.len() as isize) - 1)].into_iter())
             .collect()
@@ -158,7 +158,7 @@ macro_rules! generate_range_quantifier_block {
             .into_iter()
             // jump past end of expression
             .chain(vec![RelativeOpcode::Split((($consumer.len() + 2) as isize), 1)].into_iter())
-            .chain($consumer.into_iter())
+            .chain($consumer.clone().into_iter())
             // return to split
             .chain(vec![RelativeOpcode::Jmp(-($consumer.len() as isize) - 1)].into_iter())
             .collect()
@@ -413,13 +413,76 @@ fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
         )),
 
         // Character classes
-        Match::WithQuantifier {
-            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(_)),
-            quantifier: _,
-        } => todo!(),
         Match::WithoutQuantifier {
             item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
         } => character_class(cc),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+        } => character_class(cc)
+            .map(|rel_ops| generate_range_quantifier_block!(eager, 0, 1, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Lazy(QuantifierType::ZeroOrOne),
+        } => {
+            character_class(cc).map(|rel_ops| generate_range_quantifier_block!(lazy, 0, 1, rel_ops))
+        }
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Eager(QuantifierType::ZeroOrMore),
+        } => character_class(cc).map(|rel_ops| generate_range_quantifier_block!(eager, 0, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Lazy(QuantifierType::ZeroOrMore),
+        } => character_class(cc).map(|rel_ops| generate_range_quantifier_block!(lazy, 0, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Eager(QuantifierType::OneOrMore),
+        } => character_class(cc).map(|rel_ops| generate_range_quantifier_block!(eager, 1, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Lazy(QuantifierType::OneOrMore),
+        } => character_class(cc).map(|rel_ops| generate_range_quantifier_block!(lazy, 1, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))),
+        } => {
+            character_class(cc).map(|rel_ops| generate_range_quantifier_block!(eager, cnt, rel_ops))
+        }
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt))),
+        } => {
+            character_class(cc).map(|rel_ops| generate_range_quantifier_block!(lazy, cnt, rel_ops))
+        }
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))),
+        } => character_class(cc)
+            .map(|rel_ops| generate_range_quantifier_block!(eager, lower, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier: Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))),
+        } => character_class(cc)
+            .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier:
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }),
+        } => character_class(cc)
+            .map(|rel_ops| generate_range_quantifier_block!(eager, lower, upper, rel_ops)),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier:
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }),
+        } => character_class(cc)
+            .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, upper, rel_ops)),
 
         // Character groups
         Match::WithQuantifier {

--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -1078,11 +1078,30 @@ mod tests {
                     Opcode::Match,
                 ],
             ),
+            // approximate to `^\d??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
             // approximate to `^\d*`
             (
                 Quantifier::Eager(QuantifierType::ZeroOrMore),
                 vec![
                     Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
                     Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
                     Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
                     Opcode::Match,
@@ -1094,6 +1113,17 @@ mod tests {
                 vec![
                     Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
                     Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
                     Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
                     Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
                     Opcode::Match,

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -659,6 +659,87 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_character_class_items() {
+        use ast::*;
+        let input_output = vec![
+            (
+                "^\\w",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                },
+            ),
+            (
+                "^\\w?",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+                },
+            ),
+            (
+                "^\\w*",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::ZeroOrMore),
+                },
+            ),
+            (
+                "^\\w+",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::OneOrMore),
+                },
+            ),
+            (
+                "^\\W",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWordInverted,
+                    )),
+                },
+            ),
+            (
+                "^\\d",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyDecimalDigit,
+                    )),
+                },
+            ),
+            (
+                "^\\D",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyDecimalDigitInverted,
+                    )),
+                },
+            ),
+        ];
+
+        for (test_id, (input, class)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(class)])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+    }
+
+    #[test]
     fn should_parse_character_group_items() {
         use ast::*;
         let input_output = vec![

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -928,6 +928,92 @@ mod tests {
     }
 
     #[test]
+    fn should_evaluate_eager_character_class_zero_or_one_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 1)]), "1ab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 2)]), "123"),
+        ];
+
+        // `^\d\d?` | `^[0-9][0-9]?`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(4))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_character_class_zero_or_more_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 1)]), "1ab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 3)]), "123"),
+        ];
+
+        // `^\d\d*` | `^[0-9][0-9]*`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_character_class_one_or_more_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 1)]), "1ab"),
+            (Some(vec![SaveGroupSlot::complete(0, 0, 3)]), "123"),
+        ];
+
+        // `^\d+` | `^[0-9]+`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
     fn should_evaluate_consecutive_diverging_match_expression() {
         let progs = vec![
             (


### PR DESCRIPTION
# Introduction
This PR allows for the specification of character class quantifiers.

- `^\d\d?`
- `^\d*`
- `^\d+`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
