### PR TITLE
Quantifiers for character groups

### DIFF
--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -1310,4 +1310,99 @@ mod tests {
             compile(regex_ast)
         );
     }
+
+    #[test]
+    fn should_compile_character_groups_with_quantifiers() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^[0-9]?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Match(Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
+                        CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
+                            Char('0'),
+                            Char('9'),
+                        )]),
+                    )),
+                    quantifier,
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default()
+                        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                            '0'..='9'
+                        ))])
+                        .with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
 }

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -742,6 +742,7 @@ mod tests {
     #[test]
     fn should_parse_character_group_items() {
         use ast::*;
+
         let input_output = vec![
             (
                 "^[a]",
@@ -784,6 +785,45 @@ mod tests {
                             item: MatchItem::MatchCharacterClass(
                                 MatchCharacterClass::CharacterGroup(output)
                             )
+                        }),])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+
+        // with quantifiers
+        let input_output = vec![
+            ("^[ab]?", QuantifierType::ZeroOrOne),
+            ("^[ab]*", QuantifierType::ZeroOrMore),
+            ("^[ab]+", QuantifierType::OneOrMore),
+            ("^[ab]{1}", QuantifierType::MatchExactRange(Integer(1))),
+            ("^[ab]{1,}", QuantifierType::MatchAtLeastRange(Integer(1))),
+            (
+                "^[ab]{1,2}",
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(1),
+                    upper_bound: Integer(2),
+                },
+            ),
+        ];
+
+        for (test_id, (input, quantifier_ty)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                            item: MatchItem::MatchCharacterClass(
+                                MatchCharacterClass::CharacterGroup(CharacterGroup::Items(vec![
+                                    CharacterGroupItem::Char(Char('a')),
+                                    CharacterGroupItem::Char(Char('b')),
+                                ]))
+                            ),
+                            quantifier: Quantifier::Eager(quantifier_ty)
                         }),])
                     ])))
                 ),


### PR DESCRIPTION
# Introduction
This PR adds quantifier support to character groups. This allows the following type of patterns.

- `^[0-9]?`
- `^[0-9]*`
- `^[0-9]+`

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
