### PR TITLE
Implement non-capturing group compilation

### DIFF
--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -1427,7 +1427,7 @@ mod tests {
 
     #[test]
     fn should_compile_non_capturing_group() {
-        // approximate to `^(a)`
+        // approximate to `^(?:a)`
         let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
             SubExpressionItem::Group(Group::NonCapturing {
                 expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(


### PR DESCRIPTION
# Introduction
This PR introduces the minimal stubs to implement non-capturing, non-quantified groups.

- `^(?:a)`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
