### PR TITLE
Add non-quantified capturing save groups

### DIFF
--- a/relex/examples/grep-analogue/main.rs
+++ b/relex/examples/grep-analogue/main.rs
@@ -1,0 +1,33 @@
+use std::io::{self, BufRead};
+
+const USAGE: &str = "grep-analog PATTERN [FILE]";
+
+fn main() -> Result<(), String> {
+    let mut args = std::env::args();
+    let arg_len = args.len();
+
+    let (pattern, input) = match arg_len {
+        2 => args
+            .nth(1)
+            .ok_or_else(|| USAGE.to_string())
+            .map(|pattern| (pattern, io::stdin())),
+        _ => Err(USAGE.to_string()),
+    }?;
+
+    let pattern_input: Vec<(usize, char)> = pattern.chars().enumerate().collect();
+    let program = relex::parse(&pattern_input)
+        .map_err(|e| format!("{:?}", e))
+        .and_then(relex::compile)?;
+
+    for line in input.lock().lines() {
+        match line {
+            Ok(line) => match relex_runtime::run::<0>(&program, &line) {
+                Some(_) => println!("{}", line),
+                None => continue,
+            },
+            Err(e) => return Err(format!("{}", e)),
+        }
+    }
+
+    Ok(())
+}

--- a/relex/src/parser.rs
+++ b/relex/src/parser.rs
@@ -863,6 +863,25 @@ mod tests {
                 ])])),
             ),
             (
+                "^(a)(b)",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                    }),
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+                            }),
+                        ])]),
+                    }),
+                ])])),
+            ),
+            (
                 "^(?:a)",
                 Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
                     SubExpressionItem::Group(Group::NonCapturing {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -313,7 +313,7 @@ pub struct InstMatch;
 
 impl Display for InstMatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Match: (END)",)
+        write!(f, "Match",)
     }
 }
 
@@ -1096,7 +1096,7 @@ mod tests {
             (vec![SaveGroupSlot::complete(0, 0, 3)], "aaaab"),
         ];
 
-        // `^aaa?`
+        // `^(aaa?)`
         let prog = Instructions::default().with_opcodes(vec![
             Opcode::StartSave(InstStartSave::new(0)),
             Opcode::Consume(InstConsume::new('a')),
@@ -1104,6 +1104,7 @@ mod tests {
             Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(5))),
             Opcode::Consume(InstConsume::new('a')),
             Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
             Opcode::Match,
         ]);
 
@@ -1121,7 +1122,7 @@ mod tests {
             (Some(vec![SaveGroupSlot::complete(0, 0, 4)]), "aaaab"),
         ];
 
-        // `^aa(a?)?`
+        // `^(aaa??)`
         let prog = Instructions::default().with_opcodes(vec![
             Opcode::StartSave(InstStartSave::new(0)),
             Opcode::Consume(InstConsume::new('a')),
@@ -1130,6 +1131,7 @@ mod tests {
             Opcode::Consume(InstConsume::new('a')),
             Opcode::Consume(InstConsume::new('a')),
             Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
             Opcode::Match,
         ]);
 
@@ -1205,6 +1207,7 @@ mod tests {
             Opcode::Consume(InstConsume::new('a')),
             Opcode::EndSave(InstEndSave::new(0)),
             Opcode::Match,
+            Opcode::Match,
         ]);
 
         for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
@@ -1226,12 +1229,14 @@ mod tests {
             Opcode::Consume(InstConsume::new('a')),
             Opcode::Consume(InstConsume::new('b')),
             Opcode::Match,
+            Opcode::Match,
         ]);
 
         assert_eq!(
             "0000: Consume: 'a'
 0001: Consume: 'b'
-0002: Match: (END)\n",
+0002: Match
+0003: Match\n",
             prog.to_string()
         )
     }


### PR DESCRIPTION
# Introduction
This PR adds non-quantified capturing save groups. This allows for the parsing of the following example pattern:

- `^(ab)`

Additionally this adds a quick example binary `grep-analogue` that allows for parsing, compiling and running a pattern through the bytecode vm.
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
