### PR TITLE
Convert vector return on run to fixed array

### DIFF
--- a/relex/benches/linear.rs
+++ b/relex/benches/linear.rs
@@ -18,7 +18,7 @@ fn pad_input_to_length_with(prefix: &str, suffix: &str, pad_str: &str, len: usiz
 }
 
 pub fn exponential_input_size_comparison(c: &mut Criterion) {
-    let mut group = c.benchmark_group("exponential pattern length compilation comparison");
+    let mut group = c.benchmark_group("pattern length compilation comparison");
     let pad = "ab";
 
     (1..10)
@@ -28,7 +28,7 @@ pub fn exponential_input_size_comparison(c: &mut Criterion) {
         .for_each(|(input, sample_size)| {
             group.throughput(Throughput::Elements(sample_size as u64));
             group.bench_with_input(
-                BenchmarkId::new("find match with sample size of defined length", sample_size),
+                BenchmarkId::new("pattern input length of size", sample_size),
                 &input,
                 |b, input| {
                     b.iter(|| {

--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -38,7 +38,7 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
         .for_each(|(input, sample_size)| {
             group.throughput(Throughput::Elements(sample_size as u64));
             group.bench_with_input(
-                BenchmarkId::new("find match with sample size of defined length", sample_size),
+                BenchmarkId::new("input length of size", sample_size),
                 &(input, sample_size),
                 |b, (input, input_size)| {
                     let expected_res = SaveGroupSlot::complete(*input_size - 2, *input_size);
@@ -56,7 +56,7 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
 }
 
 pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
-    let mut group = c.benchmark_group("exponential input length comparison for set matching");
+    let mut group = c.benchmark_group("input length comparison for set matching");
     let input = "ab";
     let pad = "xy";
 
@@ -81,10 +81,7 @@ pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
         .for_each(|(input, sample_size)| {
             group.throughput(Throughput::Elements(sample_size as u64));
             group.bench_with_input(
-                BenchmarkId::new(
-                    "find match in set with sample size of defined length",
-                    sample_size,
-                ),
+                BenchmarkId::new("input length of size", sample_size),
                 &(input, sample_size),
                 |b, (input, input_size)| {
                     let expected_res = [SaveGroupSlot::complete(*input_size - 2, *input_size)];

--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -87,14 +87,11 @@ pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
                 ),
                 &(input, sample_size),
                 |b, (input, input_size)| {
-                    let expected_res = SaveGroupSlot::complete(*input_size - 2, *input_size);
+                    let expected_res = [SaveGroupSlot::complete(*input_size - 2, *input_size)];
 
                     b.iter(|| {
                         let res = run::<1>(&prog, input);
-                        assert_eq!(
-                            Some(Some(&expected_res)),
-                            res.as_ref().map(|slots| slots.get(0))
-                        )
+                        assert_eq!(Some(expected_res), res)
                     })
                 },
             );


### PR DESCRIPTION
# Introduction
This PR converts the `Option<Vec<SaveGroupSlot>>` returned from `run<const SG: usize>` to a fixed size array of the length of the `SG` parameter.

# Linked Issues
resolves #16 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
