### PR TITLE
Implement quantifiers for capturing groups

### DIFF
--- a/relex/src/compiler.rs
+++ b/relex/src/compiler.rs
@@ -627,9 +627,62 @@ fn group(g: ast::Group) -> Result<RelativeOpcodes, String> {
             })
         }
         ast::Group::CapturingWithQuantifier {
-            expression: _,
-            quantifier: _,
-        } => todo!(),
+            expression: expr,
+            quantifier,
+        } => {
+            let save_group_id = SAVE_GROUP_ID.fetch_add(1, Ordering::SeqCst);
+            let save_group_prefix = [RelativeOpcode::StartSave(save_group_id)];
+            let save_group_suffix = [RelativeOpcode::EndSave(save_group_id)];
+
+            expression(expr)
+                .map(|rel_ops| match quantifier {
+                    Quantifier::Eager(QuantifierType::ZeroOrOne) => {
+                        generate_range_quantifier_block!(eager, 0, 1, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::ZeroOrOne) => {
+                        generate_range_quantifier_block!(lazy, 0, 1, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::ZeroOrMore) => {
+                        generate_range_quantifier_block!(eager, 0, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::ZeroOrMore) => {
+                        generate_range_quantifier_block!(lazy, 0, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::OneOrMore) => {
+                        generate_range_quantifier_block!(eager, 1, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::OneOrMore) => {
+                        generate_range_quantifier_block!(lazy, 1, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                        generate_range_quantifier_block!(eager, lower, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                        generate_range_quantifier_block!(lazy, lower, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                        lower_bound: Integer(lower),
+                        upper_bound: Integer(upper),
+                    }) => generate_range_quantifier_block!(eager, lower, upper, rel_ops),
+                    Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                        lower_bound: Integer(lower),
+                        upper_bound: Integer(upper),
+                    }) => generate_range_quantifier_block!(lazy, lower, upper, rel_ops),
+                    Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+                    | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                        let multiple_of_len = rel_ops.len() * (cnt as usize);
+
+                        rel_ops.into_iter().cycle().take(multiple_of_len).collect()
+                    }
+                })
+                .map(|insts: RelativeOpcodes| {
+                    save_group_prefix
+                        .into_iter()
+                        .chain(insts.into_iter())
+                        .chain(save_group_suffix.into_iter())
+                        .collect()
+                })
+        }
 
         ast::Group::NonCapturing { expression: expr } => expression(expr),
         ast::Group::NonCapturingWithQuantifier {
@@ -1572,6 +1625,197 @@ mod tests {
         {
             let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
                 SubExpressionItem::Group(Group::NonCapturing {
+                    expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                        Match::WithQuantifier {
+                            item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            quantifier,
+                        },
+                    )])]),
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default().with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
+
+    #[test]
+    fn should_compile_quantified_capturing_group() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^(a)?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2}`
+            (
+                Quantifier::Eager(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,}`
+            (
+                Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(6))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,4}`
+            (
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(7))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,4}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(7), InstIndex::from(6))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            // reset the save group id.
+            SAVE_GROUP_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Group(Group::Capturing {
                     expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
                         Match::WithQuantifier {
                             item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1219,6 +1219,30 @@ mod tests {
     }
 
     #[test]
+    fn should_evaluate_nested_quantified_group_expression() {
+        // ^(a(b){2,})
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::StartSave(InstStartSave::new(1)),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(8))),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Jmp(InstJmp::new(InstIndex::from(5))),
+            Opcode::EndSave(InstEndSave::new(1)),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        let res = run::<2>(&prog, "abbb");
+        assert_eq!(
+            Some([SaveGroupSlot::complete(0, 4), SaveGroupSlot::complete(1, 4),]),
+            res
+        );
+    }
+
+    #[test]
     fn should_retain_a_fixed_opcode_size() {
         use core::mem::size_of;
 


### PR DESCRIPTION
# Introduction
This PR introduces capturing group quantifiers. An example of such would be:

- `^(a(b){2,})`

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
