### PR TITLE
Token Variant is to be returned by the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,42 @@
 # relex
 A lexer generator for the first principles project.
 
+## Examples
+
+in a `build.rs` script
+
+```rust
+// build.rs
+
+use std::env;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+
+const RULE_SPEC: &str = "
+RULE Number(digit: i32) [([0-9]+)] => %%{ val
+                        .parse::<i32>()
+                        .ok() }%%\n
+RULE Plus [(+)] => %%{ }%%
+RULE Semicolon [(;)] => %%{ }%%
+";
+
+fn main() -> Result<(), String> { 
+	let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("unicode_mappings.rs");
+    let cur_dir = env::current_dir().unwrap();
+
+    let input = RULE_SPEC.chars().enumerate().collect::<Vec<_>>();
+    let rule_set = relex::parser::parse(&input).map_err(|e| e.to_string())?;
+    let generated = relex::codegen::codegen(&rule_set)?;
+
+    fs::write(&dest_path, generated).map_err(|e| e.to_string())?;
+    println!("cargo:rerun-if-changed=build.rs");
+
+	Ok(())
+}
+```
+
 ## Grammar
 The grammar can be found at [relex.ebnf](./docs/relex.ebnf). Additionally this includes an [xhtml version](./docs/relex.xhtml) for viewing in a browser. This was directly generated from [relex.ebnf](./docs/relex.ebnf) with [rr](https://githug.com/ncatelli/rr-docker.git).

--- a/examples/codegen/main.rs
+++ b/examples/codegen/main.rs
@@ -1,12 +1,9 @@
 const RULE_SPEC: &str = "
-{{{}}}
 RULE Number(digit: i32) [([0-9]+)] => %%{ val
                         .parse::<i32>()
-                        .map_err(|e| e.to_string())
-                        .map(TokenVariant::Number)
                         .ok() }%%\n
-RULE Plus [(+)] => %%{ Some(TokenVariant::Plus) }%%
-RULE Semicolon [(;)] => %%{ Some(TokenVariant::Semicolon) }%%
+RULE Plus [(+)] => %%{ }%%
+RULE Semicolon [(;)] => %%{ }%%
 ";
 
 fn main() -> Result<(), String> {

--- a/examples/generated.rs
+++ b/examples/generated.rs
@@ -106,11 +106,7 @@ impl<'a> Iterator for TokenStream<'a> {
                 let val = self.input_stream.get(start..end)?;
 
                 let variant = match expression_id {
-                    0 => val
-                        .parse::<i32>()
-                        .map_err(|e| e.to_string())
-                        .map(TokenVariant::Number)
-                        .ok(),
+                    0 => val.parse::<i32>().ok().map(TokenVariant::Number),
                     1 => Some(TokenVariant::Plus),
                     2 => Some(TokenVariant::Semicolon),
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -180,7 +180,9 @@ impl From<Action> for String {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ActionItem(pub Vec<Char>);
+pub struct ActionItem {
+    pub block: Vec<Char>,
+}
 
 impl From<ActionItem> for String {
     fn from(src: ActionItem) -> Self {
@@ -190,7 +192,7 @@ impl From<ActionItem> for String {
 
 impl std::fmt::Display for ActionItem {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for c in self.0.iter().map(|c| c.as_char()) {
+        for c in self.block.iter().map(|c| c.as_char()) {
             f.write_char(c)?
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -242,14 +242,14 @@ pub fn action_item<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Ac
                     return Ok(MatchStatus::Match {
                         span: start..end - 3,
                         remainder: &input[end - 3..],
-                        inner: ast::ActionItem(
-                            (&input[start..end - 3])
+                        inner: ast::ActionItem {
+                            block: (&input[start..end - 3])
                                 .iter()
                                 .map(|(_, c)| c)
                                 .copied()
                                 .map(ast::Char)
                                 .collect(),
-                        ),
+                        },
                     })
                 }
                 // provide an early return in case it falls through to another block


### PR DESCRIPTION
# Introduction
This PR breaks the requirement that the token variant be explicitly returned at the end of the action, instead having the captured item returned in an option _IF_ there is a captured item, otherwise a blank action can be used to imply that the token variant is only returned.
# Linked Issues
resoles #44 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
