### PR TITLE
Add support for function identifiers as actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ A lexer generator for the first principles project.
 ```rust
 use relex_derive::Relex;
 
+fn float_validator(lexed_input: &str) -> Option<f32> {
+    lexed_input.parse::<f32>().ok()
+}
+
 #[derive(Relex, Debug, PartialEq)]
 pub enum Token {
-    #[matches(r"[0-9]+[.][0-9]+", |lex: &str| { lex.parse::<f32>().ok() })]
+    #[matches(r"[0-9]+[.][0-9]+", float_validator)]
     FloatLit(f32),
     #[matches(r"[0-9]+", |lex: &str| { lex.parse::<i32>().ok() })]
     IntLit(i32),
@@ -37,7 +41,7 @@ fn main() -> Result<(), String> {
 
 ### Attributes
 #### matches
-`matches` attempts to match a regular expression, associating the match with a corresponding token. Additionally, an optional closure can be passed that returns an `Option<T>` for converting the match to the corresponding field enclosed on the token's variant.
+`matches` attempts to match a regular expression, associating the match with a corresponding token. Additionally, an optional closure or function can be passed that takes a single `&str` parameter and returns an `Option<T>` for converting the match to the corresponding field enclosed on the token's variant.
 
 ```rust
 ...

--- a/relex-derive/examples/derived_dsl/main.rs
+++ b/relex-derive/examples/derived_dsl/main.rs
@@ -1,8 +1,12 @@
 use relex_derive::Relex;
 
+fn float_validator(lexed_input: &str) -> Option<f32> {
+    lexed_input.parse::<f32>().ok()
+}
+
 #[derive(Relex, Debug, PartialEq)]
 pub enum Token {
-    #[matches(r"[0-9]+[.][0-9]+", |lex: &str| { lex.parse::<f32>().ok() })]
+    #[matches(r"[0-9]+[.][0-9]+", float_validator)]
     FloatLit(f32),
     #[matches(r"[0-9]+", |lex: &str| { lex.parse::<i32>().ok() })]
     IntLit(i32),


### PR DESCRIPTION
# Introduction
This PR allows users to now pass an optional function identifier as an alternative to closures for Token actions. This allows:

```rust
#[derive(Relex, Debug, PartialEq)]
pub enum Token {
    #[matches(r"[0-9]+[.][0-9]+", |lex: &str| { lex.parse::<f32>().ok() })]
    FloatLit(f32),
...
```

To be additionally defined as:

```rust
fn float_validator(lexed_input: &str) -> Option<f32> {
    lexed_input.parse::<f32>().ok()
}

#[derive(Relex, Debug, PartialEq)]
pub enum Token {
    #[matches(r"[0-9]+[.][0-9]+", float_validator)]
    FloatLit(f32),
...
```
# Linked Issues
resolves #54 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
