### PR TITLE
Optionally map Eoi/Eof to variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ pub enum Token {
     WhiteSpace,
     #[matches("[.]")]
     Dot,
+    #[eoi]
+    Eoi,
 }
 
 fn main() -> Result<(), String> {
     let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
     for token in stream {
         println!("{:?}", token);
+        if token.variant == Token::Eoi {
+            break;
+        }
     }
 
     Ok(())
@@ -59,5 +64,15 @@ FloatLit(f32),
 ...
 #[skip(" |\t")]
 WhiteSpace,
+...
+```
+
+#### eoi
+`eoi` provides an override for a custom EOI/EOF variant on the token stream, allowing a user to define a custom alternative to the standard `None`. 
+
+```rust
+...
+#[eoi]
+Eoi,
 ...
 ```

--- a/relex-derive/examples/derived_dsl/main.rs
+++ b/relex-derive/examples/derived_dsl/main.rs
@@ -22,12 +22,17 @@ pub enum Token {
     WhiteSpace,
     #[matches("[.]")]
     Dot,
+    #[eoi]
+    Eoi,
 }
 
 fn main() -> Result<(), String> {
     let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
     for token in stream {
         println!("{:?}", token);
+        if token.variant == Token::Eoi {
+            break;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
# Introduction
This PR introduces an `eoi` attribute to optionally allow mapping of the end of input to a specific variant.

## Example
```rust
use relex_derive::Relex;

fn float_validator(lexed_input: &str) -> Option<f32> {
    lexed_input.parse::<f32>().ok()
}

#[derive(Relex, Debug, PartialEq)]
pub enum Token {
    #[matches(r"[0-9]+[.][0-9]+", float_validator)]
    FloatLit(f32),
    #[matches(r"[0-9]+", |lex: &str| { lex.parse::<i32>().ok() })]
    IntLit(i32),
    #[matches("\"[a-zA-Z]+\"", |lex: &str| { Some(lex.trim_matches('\"').to_string()) })]
    StringLit(String),
    #[matches(r"+")]
    Plus,
    #[matches(r"-")]
    Minus,
    #[matches("\n")]
    Newline,
    #[skip(" |\t")]
    WhiteSpace,
    #[matches("[.]")]
    Dot,
    #[eoi]
    Eoi,
}

fn main() -> Result<(), String> {
    let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
    for token in stream {
        println!("{:?}", token);
        if token.variant == Token::Eoi {
            break;
        }
    }

    Ok(())
}
```
# Linked Issues
resolves #56 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
