### PR TITLE
Correct multiple attribute error message.

### DIFF
--- a/relex-derive/src/lib.rs
+++ b/relex-derive/src/lib.rs
@@ -251,7 +251,7 @@ fn parse(input: DeriveInput) -> Result<TokenizerVariants, syn::Error> {
             } else {
                 Err(syn::Error::new(
                     variant_span,
-                    "expect exactly one match attribute specified",
+                    "expects exactly one attribute to be specified",
                 ))
             }
         })


### PR DESCRIPTION
# Introduction
This PR corrects a dated error message that attributes multiple attribute errors to the `match` attribute when this could really be sourced from any of the attributes in any combination.

# Linked Issues
resolves #59

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
