### PR TITLE
Add support for derived variant kinds

### DIFF
--- a/relex-derive/examples/derive_dsl/main.rs
+++ b/relex-derive/examples/derive_dsl/main.rs
@@ -29,8 +29,7 @@ pub enum Token {
 fn main() -> Result<(), String> {
     let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
     for token in stream {
-        let kind = token.variant.to_variant_kind();
-        println!("{:?} {:?}", kind, token);
+        println!("{:?}", token);
         if token.variant == Token::Eoi {
             break;
         }

--- a/relex-derive/examples/derived_dsl/main.rs
+++ b/relex-derive/examples/derived_dsl/main.rs
@@ -1,10 +1,10 @@
-use relex_derive::Relex;
+use relex_derive::{Relex, VariantKind};
 
 fn float_validator(lexed_input: &str) -> Option<f32> {
     lexed_input.parse::<f32>().ok()
 }
 
-#[derive(Relex, Debug, PartialEq)]
+#[derive(Relex, VariantKind, Debug, PartialEq)]
 pub enum Token {
     #[matches(r"[0-9]+[.][0-9]+", float_validator)]
     FloatLit(f32),
@@ -29,7 +29,8 @@ pub enum Token {
 fn main() -> Result<(), String> {
     let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
     for token in stream {
-        println!("{:?}", token);
+        let kind = token.variant.to_variant_kind();
+        println!("{:?} {:?}", kind, token);
         if token.variant == Token::Eoi {
             break;
         }

--- a/relex-derive/examples/variant_kind/main.rs
+++ b/relex-derive/examples/variant_kind/main.rs
@@ -1,0 +1,43 @@
+use relex_derive::{Relex, VariantKind};
+
+fn float_validator(lexed_input: &str) -> Option<f32> {
+    lexed_input.parse::<f32>().ok()
+}
+
+#[derive(Relex, VariantKind, Debug, PartialEq)]
+pub enum Token {
+    #[matches(r"[0-9]+[.][0-9]+", float_validator)]
+    FloatLit(f32),
+    #[matches(r"[0-9]+", |lex: &str| { lex.parse::<i32>().ok() })]
+    IntLit(i32),
+    #[matches("\"[a-zA-Z]+\"", |lex: &str| { Some(lex.trim_matches('\"').to_string()) })]
+    StringLit(String),
+    #[matches(r"+")]
+    Plus,
+    #[matches(r"-")]
+    Minus,
+    #[matches("\n")]
+    Newline,
+    #[skip(" |\t")]
+    WhiteSpace,
+    #[matches("[.]")]
+    Dot,
+    #[eoi]
+    Eoi,
+}
+
+fn main() -> Result<(), String> {
+    let stream = token_stream_from_input("2 + 12-3 + 45.0+ 4\n\t\"hello\"")?;
+    for token in stream {
+        // convert the token variant to it's representable kind.
+        let kind = token.variant.to_variant_kind();
+
+        println!("{:?}", kind);
+
+        if kind == TokenVariantKind::Eoi {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/relex-derive/src/lib.rs
+++ b/relex-derive/src/lib.rs
@@ -291,7 +291,10 @@ impl ToTokens for CodeGenHeader {
         };
 
         let variant_kind_stream = quote! {
-            pub trait RelexVariantKindRepresentable {
+            /// A trait for outputting a fieldless, copyable representation of
+            /// the token variants for pattern matching.
+            pub trait VariantKindRepresentable {
+                /// The representation type of the token enum's variants.
                 type Output;
 
                 fn to_variant_kind(&self) -> Self::Output;
@@ -646,7 +649,7 @@ impl<'a> ToTokens for CodeGenTokenVariantKind<'a> {
             .collect::<TokenStream>();
 
         let variant_kind_impl = quote! {
-            impl RelexVariantKindRepresentable for #tok_enum_ident {
+            impl VariantKindRepresentable for #tok_enum_ident {
                 type Output = #tok_variant_kind_ident;
 
                 fn to_variant_kind(&self) -> Self::Output {

--- a/relex-derive/src/lib.rs
+++ b/relex-derive/src/lib.rs
@@ -291,7 +291,7 @@ impl ToTokens for CodeGenHeader {
         };
 
         let variant_kind_stream = quote! {
-            /// A trait for outputting a fieldless, copyable representation of
+            /// A trait for outputting a field-less, copyable representation of
             /// the token variants for pattern matching.
             pub trait VariantKindRepresentable {
                 /// The representation type of the token enum's variants.


### PR DESCRIPTION
# Introduction
This PR introduces a trait and code generator for introducing copyable, field-less representations of a Token to assist downstream with pattern matching.

# Linked Issues
resolves #63 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
